### PR TITLE
Support /etc/hosts writable paths

### DIFF
--- a/backend/modules/UAdBlock/cmd.cpp
+++ b/backend/modules/UAdBlock/cmd.cpp
@@ -67,6 +67,20 @@ void Cmd::execute(const QString &cmdLine)
     }
 }
 
+int Cmd::shell(const QString &cmdLine)
+{
+    QStringList args = cmdLine.split(" ");
+    if (list.count() > 0) {
+        const QString prog = args.takeFirst();
+        QProcess proc;
+        proc.start(prog, args);
+        proc.waitForFinished();
+        return proc.exitCode();
+    } else {
+        return 1;
+    }
+}
+
 void Cmd::sudo(const QString &cmdLine)
 {
     execute("sudo -S -p passwdprompt " + cmdLine);

--- a/backend/modules/UAdBlock/cmd.h
+++ b/backend/modules/UAdBlock/cmd.h
@@ -43,6 +43,7 @@ signals:
 
 public slots:
     void execute(const QString &cmdLine);
+    int shell(const QString &cmdLine);
     void sudo(const QString &cmdLine);
     void SetPassword(QString &pass);
 


### PR DESCRIPTION
- backend: Add shell() method for unprivileged checkup commands
- app: Support /etc/hosts in writable path

With [this MR] coming up in 24.04-2.x, it will not be necessary to mount the rootfs read-writable anymore,
and blocklists will be stored persistently. In order to accommodate for both old
and new approaches we move the temporary and backup files to `/var/lib/misc/uAdBlockNG`
and check for successful enablement using `cmp`. Whether the running system supports
`/etc/hosts` in writable paths is checked via the `mountpoint` command.

This has been tested on a system with /etc/hosts in writable-paths. Please test on an unadapted system first.

[this MR]: https://gitlab.com/ubports/development/core/hybris-support/lxc-android-config/-/merge_requests/171